### PR TITLE
UPackage::SavePackage() に関するコンパイルエラーに対処

### DIFF
--- a/Private/TsubasamusuEditorUtilityLibrary.cpp
+++ b/Private/TsubasamusuEditorUtilityLibrary.cpp
@@ -58,21 +58,13 @@ UMaterialInstance* UTsubasamusuEditorUtilityLibrary::CreateMaterialInstanceAsset
 
     MaterialInstanceConstant->MarkPackageDirty();
 
-    FSavePackageArgs SavePackageArgs;
+    FString FileName = FPackageName::LongPackageNameToFilename(FinalDirectory, FPackageName::GetAssetPackageExtension());
 
-    SavePackageArgs.TopLevelFlags = EObjectFlags::RF_Public | EObjectFlags::RF_Standalone;
-
-    SavePackageArgs.Error = GError;
-
-    SavePackageArgs.bForceByteSwapping = true;
-
-    SavePackageArgs.SaveFlags = SAVE_NoError;
-
-    const bool bSaved = UPackage::SavePackage(Package, MaterialInstanceConstant, *FPackageName::LongPackageNameToFilename(FinalDirectory, FPackageName::GetAssetPackageExtension()), SavePackageArgs);
+    const bool bSaved = SavePackage(Package, MaterialInstanceConstant, FileName);
 
     if (bSaved) return Cast<UMaterialInstance>(MaterialInstanceConstant);
 
-    UE_LOG(LogTemp, Error, TEXT("Failed to save the created Package based on \"%s\"."), *SourceMaterialInstanceDynamic->GetName());
+    UE_LOG(LogTemp, Error, TEXT("Failed to save the created UPackage based on \"%s\"."), *SourceMaterialInstanceDynamic->GetName());
 
     return nullptr;
 }
@@ -114,4 +106,19 @@ void UTsubasamusuEditorUtilityLibrary::ReplaceReferences(UObject* OldAsset, UObj
         });
 
     AssetDeleteModel->Tick(ScanSpan);
+}
+
+bool UTsubasamusuEditorUtilityLibrary::SavePackage(UPackage* Package, UObject* Asset, FString& FileName)
+{
+    FSavePackageArgs SavePackageArgs;
+
+    SavePackageArgs.TopLevelFlags = EObjectFlags::RF_Public | EObjectFlags::RF_Standalone;
+
+    SavePackageArgs.Error = GError;
+
+    SavePackageArgs.bForceByteSwapping = true;
+
+    SavePackageArgs.SaveFlags = SAVE_NoError;
+
+    return UPackage::SavePackage(Package, Asset, *FileName, SavePackageArgs);
 }

--- a/Private/TsubasamusuEditorUtilityLibrary.cpp
+++ b/Private/TsubasamusuEditorUtilityLibrary.cpp
@@ -3,6 +3,7 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetDeleteModel.h"
 #include "AssetRegistry/AssetRegistryHelpers.h"
+#include "UObject/SavePackage.h"
 
 UMaterialInstance* UTsubasamusuEditorUtilityLibrary::CreateMaterialInstanceAsset(const UMaterialInstanceDynamic* SourceMaterialInstanceDynamic, const FString CreateDirectory)
 {
@@ -57,7 +58,17 @@ UMaterialInstance* UTsubasamusuEditorUtilityLibrary::CreateMaterialInstanceAsset
 
     MaterialInstanceConstant->MarkPackageDirty();
 
-    const bool bSaved = UPackage::SavePackage(Package, MaterialInstanceConstant, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone, *FPackageName::LongPackageNameToFilename(FinalDirectory, FPackageName::GetAssetPackageExtension()));
+    FSavePackageArgs SavePackageArgs;
+
+    SavePackageArgs.TopLevelFlags = EObjectFlags::RF_Public | EObjectFlags::RF_Standalone;
+
+    SavePackageArgs.Error = GError;
+
+    SavePackageArgs.bForceByteSwapping = true;
+
+    SavePackageArgs.SaveFlags = SAVE_NoError;
+
+    const bool bSaved = UPackage::SavePackage(Package, MaterialInstanceConstant, *FPackageName::LongPackageNameToFilename(FinalDirectory, FPackageName::GetAssetPackageExtension()), SavePackageArgs);
 
     if (bSaved) return Cast<UMaterialInstance>(MaterialInstanceConstant);
 

--- a/Public/TsubasamusuEditorUtilityLibrary.h
+++ b/Public/TsubasamusuEditorUtilityLibrary.h
@@ -15,4 +15,7 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "TSUBASAMUSU|EditorUtility")
 	static void ReplaceReferences(UObject* OldAsset, UObject* NewAsset);
+
+private:
+	static bool SavePackage(UPackage* Package, UObject* Asset, FString& FileName);
 };


### PR DESCRIPTION
``'UPackage::SavePackage': Pack the arguments into FSavePackageArgs and call the function overload that takes FSavePackageArgs. Note that Conform is no longer implemented. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.``